### PR TITLE
feat: memoize avatar URL on terms page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,43 @@
 import React from 'react';
 
 function App() {
-    return (
-          <div style={{ minHeight: '100vh', padding: '20px', fontFamily: 'Arial, sans-serif' }}>
-                <header style={{ textAlign: 'center', marginBottom: '40px' }}>
-                        <h1 style={{ color: '#333', fontSize: '2.5rem', marginBottom: '10px' }}>
-                                  Vida Smart Coach
-                                </h1>h1>
-                        <p style={{ color: '#666', fontSize: '1.2rem', maxWidth: '600px', margin: '0 auto' }}>
-                                  Sistema de IA Coach de Wellness via WhatsApp
-                                </p>p>
-                      </header>header>
-          
-                <main style={{ maxWidth: '800px', margin: '0 auto' }}>
-                        <div style={{ backgroundColor: '#f8f9fa', padding: '30px', borderRadius: '10px', boxShadow: '0 2px 10px rgba(0,0,0,0.1)' }}>
-                                  <h2 style={{ color: '#333', marginBottom: '20px' }}>
-                                              Bem-vindo ao Vida Smart Coach
-                                            </h2>h2>
-                                  <p style={{ color: '#666', lineHeight: '1.6', marginBottom: '20px' }}>
-                                              Transformação integral em 4 áreas: Física, Alimentar, Emocional e Espiritual
-                                            </p>p>
-                                  <div style={{ display: 'grid', gap: '10px' }}>
-                                              <div>🏃‍♂️ Física - Exercícios e condicionamento</div>div>
-                                              <div>🥗 Alimentar - Nutrição e hábitos saudáveis</div>div>
-                                              <div>🧠 Emocional - Bem-estar mental e equilíbrio</div>div>
-                                              <div>✨ Espiritual - Crescimento pessoal e propósito</div>div>
-                                            </div>div>
-                                </div>div>
-                      </main>main>
-              </div>div>
-        );
+  return (
+    <div style={{ minHeight: '100vh', padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <header style={{ textAlign: 'center', marginBottom: '40px' }}>
+        <h1 style={{ color: '#333', fontSize: '2.5rem', marginBottom: '10px' }}>
+          Vida Smart Coach
+        </h1>
+        <p style={{ color: '#666', fontSize: '1.2rem', maxWidth: '600px', margin: '0 auto' }}>
+          Sistema de IA Coach de Wellness via WhatsApp
+        </p>
+      </header>
+
+      <main style={{ maxWidth: '800px', margin: '0 auto' }}>
+        <div
+          style={{
+            backgroundColor: '#f8f9fa',
+            padding: '30px',
+            borderRadius: '10px',
+            boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
+          }}
+        >
+          <h2 style={{ color: '#333', marginBottom: '20px' }}>
+            Bem-vindo ao Vida Smart Coach
+          </h2>
+          <p style={{ color: '#666', lineHeight: '1.6', marginBottom: '20px' }}>
+            Transformação integral em 4 áreas: Física, Alimentar, Emocional e Espiritual
+          </p>
+          <div style={{ display: 'grid', gap: '10px' }}>
+            <div>🏃‍♂️ Física - Exercícios e condicionamento</div>
+            <div>🥗 Alimentar - Nutrição e hábitos saudáveis</div>
+            <div>🧠 Emocional - Bem-estar mental e equilíbrio</div>
+            <div>✨ Espiritual - Crescimento pessoal e propósito</div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
 }
 
-export default App;</div>
+export default App;
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,8 @@ import App from './App.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-    <React.StrictMode>
-        <App />
-      </React.StrictMode>React.StrictMode>
-  );</React.StrictMode>
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/src/modules/dashboard/pages/terms/main.tsx
+++ b/src/modules/dashboard/pages/terms/main.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from 'react';
+
+interface User {
+    user_metadata?: {
+        avatar_url?: string;
+    };
+}
+
+interface TermsPageProps {
+    user?: User | null;
+}
+
+/**
+ * TermsPage renders the terms dashboard page.  The avatar image URL is derived
+ * from the provided user object and memoized to avoid unnecessary recalculation
+ * on subsequent renders when the source value has not changed.
+ */
+export default function TermsPage({ user }: TermsPageProps) {
+    const avatarUrl = useMemo(() => {
+        return user?.user_metadata?.avatar_url ?? '';
+    }, [user?.user_metadata?.avatar_url]);
+
+    return (
+        <div>
+            {avatarUrl && <img src={avatarUrl} alt="User avatar" />}
+            {/* Page content goes here */}
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add terms page component with memoized avatar URL
- fix root React components to render correctly

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2456f325883258eedbace0aac0ca1