### PR TITLE
fix: improve auth session handling

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -5,16 +5,20 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 type Props = { children: React.ReactNode };
 
 export default function AppProviders({ children }: Props) {
-  // Vite usa VITE_* no client
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
   const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
-  const supabase: SupabaseClient = useMemo(() => {
-    if (!supabaseUrl || !supabaseAnon) {
-      console.warn('Supabase envs ausentes: VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY');
-    }
-    return createClient(supabaseUrl, supabaseAnon);
-  }, [supabaseUrl, supabaseAnon]);
+  if (!supabaseUrl || !supabaseAnon) {
+    console.error(
+      '[ENV] Faltam variáveis VITE_SUPABASE_URL e/ou VITE_SUPABASE_ANON_KEY. ' +
+        'Configure-as no Vercel (Production/Preview).'
+    );
+  }
+
+  const supabase: SupabaseClient = useMemo(
+    () => createClient(supabaseUrl, supabaseAnon),
+    [supabaseUrl, supabaseAnon]
+  );
 
   return <SessionContextProvider supabaseClient={supabase}>{children}</SessionContextProvider>;
 }

--- a/src/components/auth/AuthRedirection.tsx
+++ b/src/components/auth/AuthRedirection.tsx
@@ -14,9 +14,9 @@ export default function AuthRedirection() {
   }, [user, location.pathname, navigate]);
 
   useEffect(() => {
-    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
-      if (event === 'SIGNED_IN') navigate('/dashboard', { replace: true });
-      if (event === 'SIGNED_OUT') navigate('/login', { replace: true });
+    const { data: sub } = supabase.auth.onAuthStateChange((ev) => {
+      if (ev === 'SIGNED_IN') navigate('/dashboard', { replace: true });
+      if (ev === 'SIGNED_OUT') navigate('/login', { replace: true });
     });
     return () => sub.subscription.unsubscribe();
   }, [supabase, navigate]);

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,25 +1,37 @@
-import { PropsWithChildren, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSessionContext, useSupabaseClient } from '@supabase/auth-helpers-react';
 
 export default function RequireAuth({ children }: PropsWithChildren) {
-  const { isLoading, session } = useSessionContext();
   const navigate = useNavigate();
+  const { isLoading, session } = useSessionContext();
+  const supabase = useSupabaseClient();
+  const [ready, setReady] = useState(false);
+  const askedRef = useRef(false);
 
-  // Enquanto o Supabase ainda carrega a sessão, mostra um loading simples
-  if (isLoading) {
-    return <div style={{ padding: 24 }}>Carregando...</div>;
-  }
-
-  // Se não tem sessão, manda para /login
+  // Se carregar demais, força checar a sessão
   useEffect(() => {
-    if (!isLoading && !session) {
-      navigate("/login", { replace: true });
+    let t: any;
+    if (isLoading && !askedRef.current) {
+      askedRef.current = true;
+      // tenta resolver imediatamente
+      supabase.auth.getSession().finally(() => setReady(true));
+      // fallback de 3s para não travar
+      t = setTimeout(() => setReady(true), 3000);
     }
-  }, [isLoading, session, navigate]);
+    return () => clearTimeout(t);
+  }, [isLoading, supabase]);
 
-  // Se tem sessão, renderiza o conteúdo protegido
-  if (session) return <>{children}</>;
-  return null; // evita flicker
+  // Redireciona se não houver sessão quando já estiver pronto
+  useEffect(() => {
+    if (!isLoading && ready && !session) {
+      navigate('/login', { replace: true });
+    }
+  }, [isLoading, ready, session, navigate]);
+
+  if (isLoading && !ready) return <div style={{ padding: 24 }}>Carregando...</div>;
+  if (!session) return null; // evitar flicker rápido antes do redirect
+
+  return <>{children}</>;
 }
 


### PR DESCRIPTION
## Summary
- validate Supabase env vars on startup
- force session resolution if loading takes too long
- simplify auth redirection listener setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf527814d48325b834aee528715dbe