### PR TITLE
feat: add email verify guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as ShadcnToaster } from '@/components/ui/toaster';
 import { Toaster as HotToaster } from 'react-hot-toast';
 import RequireAuth from '@/components/auth/RequireAuth';
 import AuthRedirection from '@/components/auth/AuthRedirection';
+import EmailVerifyGuard from '@/components/auth/EmailVerifyGuard';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import LandingPage from '@/pages/LandingPage';
 import LoginPage from '@/pages/LoginPage';
@@ -25,6 +26,7 @@ import { CartProvider } from '@/hooks/useCart';
 function App() {
   return (
     <>
+      <EmailVerifyGuard />
       <AuthRedirection />
       <Routes>
         <Route path="/" element={<LandingPage />} />

--- a/src/components/auth/EmailVerifyGuard.tsx
+++ b/src/components/auth/EmailVerifyGuard.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+
+export default function EmailVerifyGuard() {
+  const [params] = useSearchParams();
+  const supabase = useSupabaseClient();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const code = params.get('code') || params.get('token_hash');
+    const type = params.get('type'); // 'signup' | 'magiclink' | 'recovery'...
+
+    // Sem código na URL? Não chama verify.
+    if (!code || !type) return;
+
+    (async () => {
+      const { error } = await supabase.auth.verifyOtp({
+        type: type as any,
+        token_hash: code,
+      });
+      // opcional: trate o erro/sucesso aqui
+      navigate('/dashboard', { replace: true });
+    })();
+  }, [params, supabase, navigate]);
+
+  return null;
+}
+

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -48,7 +48,7 @@ const LoginPage = () => {
     e.preventDefault();
     setLocalLoading(true);
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email: loginData.email,
         password: loginData.password,
       });
@@ -56,7 +56,7 @@ const LoginPage = () => {
         toast.error(error.message || 'Falha ao entrar. Tente novamente.');
         return;
       }
-      navigate('/dashboard', { replace: true });
+      if (data?.session) navigate('/dashboard', { replace: true });
     } catch (err) {
       toast.error(err?.message ?? 'Falha ao entrar. Tente novamente.');
     } finally {


### PR DESCRIPTION
## Summary
- avoid calling verify OTP when code missing via EmailVerifyGuard
- redirect to dashboard after login using signInWithPassword
- wire email guard into app layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf6c06f0508325adaa3e29cfcd6c5f