### PR TITLE
refactor: use singleton Supabase client

### DIFF
--- a/lib/customSupabaseClient.js
+++ b/lib/customSupabaseClient.js
@@ -1,7 +1,1 @@
-
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabase } from '../src/lib/supabaseClient.js';

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -1,25 +1,8 @@
-import { useMemo } from 'react';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabaseClient';
 
 type Props = { children: React.ReactNode };
 
 export default function AppProviders({ children }: Props) {
-  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-  const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-  if (!supabaseUrl || !supabaseAnon) {
-    console.error(
-      '[ENV] Faltam variáveis VITE_SUPABASE_URL e/ou VITE_SUPABASE_ANON_KEY. ' +
-        'Configure-as no Vercel (Production/Preview).'
-    );
-  }
-
-  const supabase: SupabaseClient = useMemo(
-    () => createClient(supabaseUrl, supabaseAnon),
-    [supabaseUrl, supabaseAnon]
-  );
-
   return <SessionContextProvider supabaseClient={supabase}>{children}</SessionContextProvider>;
 }
-

--- a/src/core/supabase.js
+++ b/src/core/supabase.js
@@ -1,20 +1,5 @@
-
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Configuração do Supabase incompleta. Verifique as variáveis VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY.');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-  },
-});
+export { supabase } from '@/lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient';
 
 export const invokeFn = async (functionName, body) => {
   if (import.meta.env.VITE_FUNCTIONS_ENABLED !== 'true') {

--- a/src/lib/customSupabaseClient.js
+++ b/src/lib/customSupabaseClient.js
@@ -1,6 +1,1 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabase } from '@/lib/supabaseClient';

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,7 +1,18 @@
-
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase =
+  globalThis.__supabase_singleton ??
+  (globalThis.__supabase_singleton = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storageKey: 'vida-smart-auth',
+    },
+  }));
+
+globalThis.__supabase_boots = (globalThis.__supabase_boots ?? 0) + 1;
+console.info('BOOT: criando supabase client', globalThis.__supabase_boots);


### PR DESCRIPTION
## Summary
- create Supabase client singleton with session persistence
- reuse singleton in provider and reexport from shared modules
- remove duplicate client creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfadc8cd848325b83bc376370f204f