### PR TITLE
fix: unificar Supabase client, adicionar view pública de comunidade, prevenir loops de fetch e melhorar UX de erro (compat name/points_required/total_points).

### DIFF
--- a/src/contexts/data/useAdminClients.js
+++ b/src/contexts/data/useAdminClients.js
@@ -31,15 +31,21 @@ export const useAdminClients = (
         .in('role', ['client']);
 
       if (error) throw error;
-      
-      const formattedData = data.map(c => ({
-        ...c,
-        full_name: c.name,
-        points: c.gamification?.total_points || 0,
-        user_id: c.user_id,
-        email: c.users?.email || 'N/A'
-      }));
-      setClients(formattedData || []);
+
+      const formattedData = (data || []).map(row => {
+        const name = row.name ?? 'Usuário';
+        const total_points = Number(row.gamification?.total_points ?? 0);
+        return {
+          ...row,
+          name,
+          total_points,
+          full_name: name,
+          points: total_points,
+          user_id: row.user_id,
+          email: row.users?.email || 'N/A'
+        };
+      });
+      setClients(formattedData);
 
     } catch (error) {
       toast.error('Falha ao carregar clientes.');
@@ -89,7 +95,7 @@ export const useAdminClients = (
     if (fetchedRef.current) return;
     fetchedRef.current = true;
     fetchClients();
-  }, [fetchClients]);
+  }, [supabaseClient]);
 
   return {
     clients,

--- a/src/core/supabase.js
+++ b/src/core/supabase.js
@@ -1,15 +1,12 @@
 export { supabase } from '@/lib/supabaseClient';
 
-/** Invoca Supabase Edge Functions com tratamento de erro consistente. */
+/** Invoca Edge Functions com tratamento de erro consistente. */
 export const invokeFn = async (functionName, body) => {
   try {
     const { data, error } = await supabase.functions.invoke(functionName, {
       body: body ?? {},
     });
-    if (error) {
-      const msg = error?.message || String(error);
-      throw new Error(msg);
-    }
+    if (error) throw new Error(error.message || 'Request failed');
     return data;
   } catch (err) {
     console.error(`Erro na função '${functionName}':`, err);


### PR DESCRIPTION
## Summary
- centralize Supabase client with consistent Edge Function invocation helper
- sanitize community ranking and plans/rewards data while guarding fetch effects
- normalize admin client list data for backwards compatibility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c03f86dc4c83259102b2a047b4d54f