### PR TITLE
fix(critical): Restore working main.tsx structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,13 @@ import { Routes, Route } from 'react-router-dom';
 import LoginPage from '@/pages/LoginPage';
 import ClientDashboard from '@/pages/ClientDashboard';
 import SafeStatus from '@/pages/SafeStatus';
-import AuthRedirection from '@/components/auth/AuthRedirection';
 import { DataProvider } from '@/contexts/DataContext';
 
 function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/dashboard" element={<AuthRedirection><DataProvider><ClientDashboard /></DataProvider></AuthRedirection>} />
+      <Route path="/dashboard" element={<DataProvider><ClientDashboard /></DataProvider>} />
       <Route path="/safe" element={<SafeStatus />} />
       <Route path="*" element={
         <div className="min-h-screen flex items-center justify-center bg-gray-50">

--- a/src/components/auth/AuthRedirection.tsx
+++ b/src/components/auth/AuthRedirection.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useAuth } from '@/contexts/SupabaseAuthContext_FINAL';
+import { useAuth } from '@/components/auth/AuthProvider';
 
 export default function AuthRedirection({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import './utils/sw-cleanup-enhanced';
+import AuthProvider from './components/auth/AuthProvider';
+import AuthRedirection from './components/auth/AuthRedirection';
 import App from './App';
+import './index.css';
 
-// IMPORTS EXATOS – use o caminho real encontrado
-import { AuthProvider } from '@/contexts/SupabaseAuthContext_FINAL';
-import { DataProvider } from '@/contexts/DataContext';
+// Debug import (apenas em desenvolvimento)  
+if (import.meta.env.MODE === 'development') {
+  import('./debug.js');
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <DataProvider>
+    <AuthProvider>
+      <BrowserRouter>
+        <AuthRedirection>
           <App />
-        </DataProvider>
-      </AuthProvider>
-    </BrowserRouter>
+        </AuthRedirection>
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
- Restore original main.tsx with correct AuthProvider and structure
- Fix AuthRedirection import to use correct AuthProvider
- Remove duplicate AuthRedirection from individual routes
- Keep DataProvider only on dashboard route where needed
- This should resolve blank pages on /safe and /login